### PR TITLE
Add main bot program/config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-Bot
+## McPy Discord Bot!
+This is the discord bot used in the McPy discord server.

--- a/bot.py
+++ b/bot.py
@@ -20,9 +20,9 @@ async def branch(ctx, arg):
 @client.command()
 async def repo(ctx, arg):
     if (arg == 'main' or arg == 'mcpy'):
-        await ctx.send(f'The github repo for McPy is located at https://github.com/mcpyproject/McPy')
+        await ctx.send('The github repo for McPy is located at https://github.com/mcpyproject/McPy')
     if (arg == 'bot'):
-        await ctx.send(f'The github repo for the McPy discord bot is located at https://github.com/mcpyproject/mcpy-bot') 
+        await ctx.send('The github repo for the McPy discord bot is located at https://github.com/mcpyproject/mcpy-bot') 
 
 @client.command()
 async def tryitandsee(ctx):

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,40 @@
+import discord
+import json
+from discord.ext import commands
+
+with open('config.json') as f:
+    configData = json.load(f)
+
+client = commands.Bot(command_prefix = configData['prefix'])
+
+@client.event
+async def on_ready():
+    activity = discord.Game(name="PyCharm vs. Jupyter vs. Visual Studio Code", type=1)
+    await client.change_presence(status=discord.Status.online, activity=activity)
+    print('Bot is ready')
+
+@client.command()
+async def branch(ctx, arg):
+    await ctx.send(f'You can access the {arg} branch by running ``git checkout {arg}``')
+
+@client.command()
+async def repo(ctx, arg):
+    if (arg == 'main' or arg == 'mcpy'):
+        await ctx.send(f'The github repo for McPy is located at https://github.com/mcpyproject/McPy')
+    if (arg == 'bot'):
+        await ctx.send(f'The github repo for the McPy discord bot is located at https://github.com/mcpyproject/mcpy-bot') 
+
+@client.command()
+async def tryitandsee(ctx):
+    await ctx.send("It's now time to https://tryitands.ee")
+
+@client.command()
+async def install(ctx, arg):
+    if (arg == 'python3' or arg == 'python3.8' or arg == 'python'):
+        await ctx.send('Python 3.8 can be installed by following the instructions at https://www.python.org/downloads/release/python-387/')
+    if (arg == 'submodules' or arg == 'submodule'):
+        await ctx.send('In your McPy directory, run ``git submodule init`` and ``git submodule update``')
+    if (arg == 'pip' or arg == 'pip3'):
+        await ctx.send("Pip can be installed with either ``python3 -m ensurepip``, or on Debian-based Linux distributions use ``sudo apt install python3-pip``.")
+
+client.run(configData['token'])

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,4 @@
+{
+    "token": " --TOKEN HERE-- ",
+    "prefix": "."
+}


### PR DESCRIPTION
This PR adds the main program file and adds a config file so no one accidentally commits their test bot token.

Commands added (I wasn't sure what to add, so I went through the support channels and added commands based on what was there):

- Branch - You can do ``.branch <branch name>`` to return the way to move branches
- Repo - You can do ``.repo <repo name>`` to return the link for either the main repo (main/mcpy) or the bot repo (bot)
- Install - You can do ``.install <arg>`` to return either the link to the documentation or the process for installing:
        - Python - Link to python download for 3.8.7 (python, python3, python3.8)
        - Git Submodules - Commands needed to install submodules (submodules, submodule
        - Pip - Commands needed to install pip. Uses module "ensurepip" and "apt" for Debian-based distros
- Tryitandsee - You can do ``.tryitandsee`` to return the link to the video. I don't know why I added this, but it was in the update channel, so...